### PR TITLE
Improve login and signup pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ export ADMIN_EMAIL=admin@example.com
 ```
 
 Run the PHP files through a local server of your choice.
+
+## Authentication
+
+Users can register at `register.php` (or `signup.php`) and log in via
+`login.php`. A `logout.php` script is provided to end the session.

--- a/login.php
+++ b/login.php
@@ -2,44 +2,68 @@
 session_start();
 require_once __DIR__ . '/config/db.php';
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $username = trim($_POST['username'] ?? '');
-    $password = trim($_POST['password'] ?? '');
-    $stmt = $pdo->prepare('SELECT id, password, role FROM users WHERE username = ?');
-    $stmt->execute([$username]);
-    $user = $stmt->fetch();
-    if ($user && password_verify($password, $user['password'])) {
-        $_SESSION['user_id'] = $user['id'];
-        $_SESSION['role'] = $user['role'];
-        if ($user['role'] === 'admin') {
-            $_SESSION['admin_logged_in'] = true;
-            header('Location: admin/dashboard.php');
-        } else {
-            header('Location: index.html');
-        }
-        exit;
+if (isset($_SESSION['user_id'])) {
+    if ($_SESSION['role'] === 'admin') {
+        header('Location: admin/dashboard.php');
     } else {
-        $error = 'Invalid credentials';
+        header('Location: index.html');
+    }
+    exit;
+}
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim(filter_input(INPUT_POST, 'username', FILTER_SANITIZE_STRING));
+    $password = trim($_POST['password'] ?? '');
+    if ($username && $password) {
+        $stmt = $pdo->prepare('SELECT id, password, role FROM users WHERE username = ?');
+        $stmt->execute([$username]);
+        $user = $stmt->fetch();
+        if ($user && password_verify($password, $user['password'])) {
+            session_regenerate_id(true);
+            $_SESSION['user_id'] = $user['id'];
+            $_SESSION['role'] = $user['role'];
+            if ($user['role'] === 'admin') {
+                $_SESSION['admin_logged_in'] = true;
+                header('Location: admin/dashboard.php');
+            } else {
+                header('Location: index.html');
+            }
+            exit;
+        } else {
+            $error = 'Invalid credentials';
+        }
+    } else {
+        $error = 'All fields are required';
     }
 }
 ?>
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
     <title>Login</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet" />
-    <link rel="stylesheet" href="style.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<h2>User Login</h2>
-<?php if (!empty($error)) echo "<p style='color:red;'>$error</p>"; ?>
-<form method="post">
-    <label>Username:<input type="text" name="username" required></label><br>
-    <label>Password:<input type="password" name="password" required></label><br>
-    <button type="submit">Login</button>
-</form>
-<p><a href="signup.php">Sign up</a></p>
+<div class="auth-container">
+    <h2>User Login</h2>
+    <?php if ($error): ?>
+        <p class="error"><?= htmlspecialchars($error) ?></p>
+    <?php endif; ?>
+    <form method="post" class="auth-form">
+        <label>Username
+            <input type="text" name="username" required>
+        </label>
+        <label>Password
+            <input type="password" name="password" required>
+        </label>
+        <button type="submit" class="button">Login</button>
+    </form>
+    <p class="auth-switch"><a href="register.php">Need an account? Sign up</a></p>
+</div>
 </body>
 </html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,7 @@
+<?php
+session_start();
+session_unset();
+session_destroy();
+header('Location: index.html');
+exit;
+?>

--- a/signup.php
+++ b/signup.php
@@ -2,8 +2,14 @@
 session_start();
 require_once __DIR__ . '/config/db.php';
 
+if (isset($_SESSION['user_id'])) {
+    header('Location: index.html');
+    exit;
+}
+
+$error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $username = trim($_POST['username'] ?? '');
+    $username = trim(filter_input(INPUT_POST, 'username', FILTER_SANITIZE_STRING));
     $password = trim($_POST['password'] ?? '');
     if ($username && $password) {
         $stmt = $pdo->prepare('SELECT id FROM users WHERE username = ?');
@@ -11,10 +17,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($stmt->fetch()) {
             $error = 'Username already exists';
         } else {
-            $hash = password_hash($password, PASSWORD_BCRYPT);
+            $hash = password_hash($password, PASSWORD_DEFAULT);
             $insert = $pdo->prepare('INSERT INTO users (username, password) VALUES (?, ?)');
             $insert->execute([$username, $hash]);
+            session_regenerate_id(true);
             $_SESSION['user_id'] = $pdo->lastInsertId();
+            $_SESSION['role'] = 'user';
             header('Location: index.html');
             exit;
         }
@@ -24,21 +32,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 ?>
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+    <meta charset="UTF-8">
     <title>Signup</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet" />
-    <link rel="stylesheet" href="style.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<h2>User Signup</h2>
-<?php if (!empty($error)) echo "<p style='color:red;'>$error</p>"; ?>
-<form method="post">
-    <label>Username:<input type="text" name="username" required></label><br>
-    <label>Password:<input type="password" name="password" required></label><br>
-    <button type="submit">Sign Up</button>
-</form>
+<div class="auth-container">
+    <h2>User Signup</h2>
+    <?php if ($error): ?>
+        <p class="error"><?= htmlspecialchars($error) ?></p>
+    <?php endif; ?>
+    <form method="post" class="auth-form">
+        <label>Username
+            <input type="text" name="username" required>
+        </label>
+        <label>Password
+            <input type="password" name="password" required>
+        </label>
+        <button type="submit" class="button">Sign Up</button>
+    </form>
+    <p class="auth-switch"><a href="login.php">Already have an account? Login</a></p>
+</div>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -192,3 +192,42 @@ h2 {
   display: none;
   margin: 1rem auto;
 }
+
+/* Auth Pages */
+.auth-container {
+  max-width: 400px;
+  margin: 2rem auto;
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.auth-form label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.auth-form input {
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+  margin-bottom: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+.auth-form button {
+  width: 100%;
+}
+
+.error {
+  color: red;
+  margin-bottom: 1rem;
+}
+
+.auth-switch {
+  text-align: center;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- restyle pages with an auth container
- harden login logic with better validation
- harden signup logic
- add logout script
- document auth pages in README

## Testing
- `php -l login.php`
- `php -l signup.php`
- `php -l logout.php`
- `php final_testing.php` *(fails: Database connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a9966f380832c90137933ae879a70