### PR TITLE
Use environment variables for DB configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,22 @@ This project is a simple PHP demo for submitting and voting on deals.
 
 ## Setup
 
-Create a MySQL database using `config/spicybeats_schema.sql` and provide the
-connection credentials via environment variables:
+Create a MySQL database using `config/spicybeats_schema.sql`. The application
+reads its connection credentials from environment variables. At a minimum,
+`DB_NAME`, `DB_USER`, and `DB_PASS` must be set. `DB_HOST` and `DB_CHARSET`
+are optional and default to `localhost` and `utf8mb4` respectively.
 
 ```
 export DB_HOST=localhost
 export DB_NAME=your_database
 export DB_USER=your_user
 export DB_PASS=your_pass
+export DB_CHARSET=utf8mb4
 export ADMIN_EMAIL=admin@example.com
 ```
 
-Run the PHP files through a local server of your choice.
+If any required variables are missing the application will exit with an
+error. Run the PHP files through a local server of your choice.
 
 ## Authentication
 

--- a/config/db.php
+++ b/config/db.php
@@ -1,9 +1,14 @@
 <?php
-$host = 'localhost';
-$db   = 'spicybeats';
-$user = 'root';
-$pass = '';
-$charset = 'utf8mb4';
+$host = getenv('DB_HOST') ?: 'localhost';
+$db   = getenv('DB_NAME');
+$user = getenv('DB_USER');
+$pass = getenv('DB_PASS');
+$charset = getenv('DB_CHARSET') ?: 'utf8mb4';
+
+if ($db === false || $user === false || $pass === false) {
+    die('Missing required database environment variables.');
+}
+
 $dsn = "mysql:host=$host;dbname=$db;charset=$charset";
 
 $options = [
@@ -11,9 +16,10 @@ $options = [
     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
     PDO::ATTR_EMULATE_PREPARES   => false,
 ];
+
 try {
-     $pdo = new PDO($dsn, $user, $pass, $options);
+    $pdo = new PDO($dsn, $user, $pass, $options);
 } catch (Exception $e) {
-     die('Connection failed: ' . $e->getMessage());
+    die('Connection failed: ' . $e->getMessage());
 }
 ?>


### PR DESCRIPTION
## Summary
- Load database credentials from environment variables in `config/db.php` and fail gracefully when required values are missing
- Document required DB environment variables with optional defaults in the README

## Testing
- `php -l config/db.php`


------
https://chatgpt.com/codex/tasks/task_e_689120a55b84832cac21ea188d663958