### PR TITLE
Fix chat API room parameter

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -34,7 +34,7 @@ console.log("Sending chat:", { username, msg, room });
     fetch("chat_api.php", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ username, message: msg, room_name: room })
+      body: JSON.stringify({ username, message: msg, room })
     })
     .then(res => res.json())
     .then(data => {


### PR DESCRIPTION
## Summary
- Update chat.js to send the `room` parameter expected by `chat_api.php`

## Testing
- `curl -s -X POST -H "Content-Type: application/json" -d '{"username":"alice","message":"hi","room":"test"}' http://localhost:8000/chat_api.php` *(fails: Connection failed: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689120c1e9f8832c809fd459c9a7c846