### PR TITLE
Validate chat user via session

### DIFF
--- a/api/session.php
+++ b/api/session.php
@@ -1,0 +1,9 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+
+if (isset($_SESSION['username'])) {
+    echo json_encode(['loggedIn' => true, 'username' => $_SESSION['username']]);
+} else {
+    echo json_encode(['loggedIn' => false]);
+}

--- a/chat.js
+++ b/chat.js
@@ -5,47 +5,73 @@ console.log("💬 chat.js running...");
   const input = document.getElementById("chat-message-input");
   const messages = document.getElementById("chat-messages");
   const roomSelect = document.getElementById("chat-room-select");
-  const username = localStorage.getItem("username");
 
-  if (!sendBtn || !input || !messages || !roomSelect || !username) {
-    console.warn("❌ Chat elements or username missing");
+  if (!sendBtn || !input || !messages || !roomSelect) {
+    console.warn("❌ Chat elements missing");
     return;
   }
 
-  sendBtn.addEventListener("click", () => {
-    const msg = input.value.trim();
-    const room = roomSelect.value;
-
-    if (msg === "" || !room) {
-      console.warn("❌ Empty message or missing room");
-      return;
-    }
-
-    // Add message to chat UI
+  function disableChat() {
+    sendBtn.disabled = true;
+    input.disabled = true;
     const msgDiv = document.createElement("div");
-    msgDiv.className = "chat-message user";
-    msgDiv.innerHTML = `<strong>${username}:</strong> ${msg}`;
+    msgDiv.className = "chat-message system";
+    msgDiv.textContent = "Please log in to chat.";
     messages.appendChild(msgDiv);
-    input.value = "";
-    messages.scrollTop = messages.scrollHeight;
-console.log("Sending chat:", { username, msg, room });
+  }
 
-    // Send to backend
-    fetch("chat_api.php", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ username, message: msg, room_name: room })
-    })
+  fetch("api/session.php")
     .then(res => res.json())
     .then(data => {
-      if (!data.success) {
-        console.warn("⚠️ Failed to store chat message:", data.error || "Unknown error");
+      if (!data.loggedIn) {
+        localStorage.removeItem("username");
+        disableChat();
+        return;
       }
+
+      const username = data.username;
+      localStorage.setItem("username", username);
+
+      sendBtn.addEventListener("click", () => {
+        const msg = input.value.trim();
+        const room = roomSelect.value;
+
+        if (msg === "" || !room) {
+          console.warn("❌ Empty message or missing room");
+          return;
+        }
+
+        // Add message to chat UI
+        const msgDiv = document.createElement("div");
+        msgDiv.className = "chat-message user";
+        msgDiv.innerHTML = `<strong>${username}:</strong> ${msg}`;
+        messages.appendChild(msgDiv);
+        input.value = "";
+        messages.scrollTop = messages.scrollHeight;
+
+        console.log("Sending chat:", { username, msg, room });
+
+        // Send to backend
+        fetch("chat_api.php", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ username, message: msg, room_name: room })
+        })
+          .then(res => res.json())
+          .then(data => {
+            if (!data.success) {
+              console.warn("⚠️ Failed to store chat message:", data.error || "Unknown error");
+            }
+          })
+          .catch(err => {
+            console.error("❌ Chat API error:", err);
+          });
+      });
     })
     .catch(err => {
-      console.error("❌ Chat API error:", err);
+      console.error("❌ Session check failed:", err);
+      disableChat();
     });
-  });
 
   // Chat widget controls
   const closeBtn = document.getElementById("close-chat");

--- a/login.php
+++ b/login.php
@@ -23,6 +23,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             session_regenerate_id(true);
             $_SESSION['user_id'] = $user['id'];
             $_SESSION['role'] = $user['role'];
+            $_SESSION['username'] = $username;
             if ($user['role'] === 'admin') {
                 $_SESSION['admin_logged_in'] = true;
                 header('Location: admin/dashboard.php');


### PR DESCRIPTION
## Summary
- Add session endpoint exposing logged-in username
- Persist username in session during login
- Fetch username on the chat client to verify localStorage and disable chat for guests

## Testing
- `php -l login.php`
- `php -l api/session.php`
- `node --check chat.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_689120ba15bc832c89df8f3bdecc90bc