### PR TITLE
Add image upload validation

### DIFF
--- a/submit_deal.php
+++ b/submit_deal.php
@@ -15,6 +15,8 @@ $cat = $_POST['category'] ?? '';
 $user_id = $_SESSION['user_id'];
 $upload_dir = 'uploads/';
 $default_image = 'uploads/default.jpg';
+$allowed_types = ['image/jpeg', 'image/png', 'image/gif'];
+$max_file_size = 5 * 1024 * 1024; // 5MB
 
 $pdo->beginTransaction();
 try {
@@ -25,10 +27,25 @@ try {
     foreach ($_FILES['images']['tmp_name'] as $i => $tmpName) {
         if ($_FILES['images']['error'][$i] !== UPLOAD_ERR_OK) continue;
 
+        if ($_FILES['images']['size'][$i] > $max_file_size) {
+            throw new Exception('File too large.');
+        }
+
+        $mime = mime_content_type($tmpName);
+        if (!in_array($mime, $allowed_types)) {
+            throw new Exception('Invalid image type.');
+        }
+
+        $imageInfo = getimagesize($tmpName);
+        if ($imageInfo === false) {
+            throw new Exception('Invalid image file.');
+        }
+
+        list($w, $h) = $imageInfo;
+
         $filename = "deal_{$deal_id}_" . time() . "_{$i}.jpg";
         $target = $upload_dir . $filename;
 
-        list($w, $h) = getimagesize($tmpName);
         $src = imagecreatefromstring(file_get_contents($tmpName));
         $dst = imagecreatetruecolor(800, 600);
         imagecopyresampled($dst, $src, 0, 0, 0, 0, 800, 600, $w, $h);
@@ -46,6 +63,6 @@ try {
     echo "<script>alert('Deal submitted successfully!'); window.location='index.html';</script>";
 } catch (Exception $e) {
     $pdo->rollBack();
-    die("Error: " . $e->getMessage());
+    echo "<script>alert('" . addslashes($e->getMessage()) . "'); window.history.back();</script>";
 }
 ?>


### PR DESCRIPTION
## Summary
- validate uploaded images against MIME type and file size limits
- restrict uploads to JPG, PNG, and GIF formats
- show user-friendly error messages when validation fails

## Testing
- `php -l submit_deal.php`


------
https://chatgpt.com/codex/tasks/task_e_6891209e6540832c831ffadc7d783f12