### PR TITLE
Sanitize numeric GET parameters

### DIFF
--- a/admin/approve.php
+++ b/admin/approve.php
@@ -4,7 +4,7 @@
 require_once __DIR__ . '/config/auth_check.php';
 require_once __DIR__ . '/config/db.php';
 
-$id = $_GET['id'] ?? 0;
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 if ($id) {
     $stmt = $pdo->prepare("UPDATE deals SET status = 'approved' WHERE id = ?");
     $stmt->execute([$id]);

--- a/admin/delete.php
+++ b/admin/delete.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/config/auth_check.php';
 require_once __DIR__ . '/config/db.php';
 
-$id = $_GET['id'] ?? 0;
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 if (!$id) {
     // Invalid id; optionally display an error message or log
     header('Location: dashboard.php');

--- a/admin/pin.php
+++ b/admin/pin.php
@@ -2,7 +2,7 @@
 require_once 'config/auth_check.php';
 require_once 'config/db.php';
 
-$deal_id = $_GET['id'] ?? 0;
+$deal_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 
 $stmt = $pdo->prepare("SELECT is_pinned FROM deals WHERE id = ?");
 $stmt->execute([$deal_id]);

--- a/admin/reject.php
+++ b/admin/reject.php
@@ -4,7 +4,7 @@
 require_once __DIR__ . '/config/auth_check.php';
 require_once __DIR__ . '/config/db.php';
 
-$id = $_GET['id'] ?? 0;
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 if ($id) {
     $stmt = $pdo->prepare('DELETE FROM deals WHERE id = ?');
     $stmt->execute([$id]);

--- a/admin/view_comments.php
+++ b/admin/view_comments.php
@@ -2,7 +2,7 @@
 require_once 'config/auth_check.php';
 require_once 'config/db.php';
 
-$deal_id = $_GET['deal_id'] ?? 0;
+$deal_id = isset($_GET['deal_id']) ? (int)$_GET['deal_id'] : 0;
 
 $stmt = $pdo->prepare("SELECT comments.*, users.username FROM comments LEFT JOIN users ON comments.user_id = users.id WHERE comments.deal_id = ?");
 $stmt->execute([$deal_id]);

--- a/api/check_bookmark.php
+++ b/api/check_bookmark.php
@@ -4,7 +4,7 @@ header('Content-Type: application/json');
 require_once '../config/db.php';
 
 $username = $_GET['username'] ?? '';
-$deal_id = $_GET['deal_id'] ?? '';
+$deal_id = isset($_GET['deal_id']) ? (int)$_GET['deal_id'] : 0;
 
 if (!$username || !$deal_id) {
   echo json_encode(['success' => false, 'error' => 'Missing parameters']);
@@ -16,3 +16,4 @@ $stmt->execute([$username, $deal_id]);
 $exists = $stmt->fetch();
 
 echo json_encode(['success' => true, 'bookmarked' => !!$exists]);
+

--- a/api/increment_view.php
+++ b/api/increment_view.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/config/db.php';
 
-$deal_id = $_GET['id'] ?? null;
+$deal_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 
 if (!$deal_id) {
     echo json_encode(['error' => 'Missing deal_id']);


### PR DESCRIPTION
## Summary
- cast id parameters to integers in admin tools and API endpoints

## Testing
- `php -l admin/delete.php admin/approve.php admin/reject.php admin/pin.php admin/view_comments.php api/increment_view.php api/check_bookmark.php`


------
https://chatgpt.com/codex/tasks/task_e_6896d699b2fc832cb481e17abee1b51a